### PR TITLE
Renomear "Espanhol" para "espanhol" em ola-mundo

### DIFF
--- a/primeiros-passos-com-go/ola-mundo/ola-mundo.md
+++ b/primeiros-passos-com-go/ola-mundo/ola-mundo.md
@@ -379,7 +379,7 @@ func Ola(nome string, idioma string) string {
         nome = "Mundo"
     }
 
-    if idioma == "Espanhol" {
+    if idioma == "espanhol" {
         return "Hola, " + nome
     }
 


### PR DESCRIPTION
Na seção [`Continue! Mais requisitos`](https://larien.gitbook.io/aprenda-go-com-testes/primeiros-passos-com-go/ola-mundo#continue-mais-requisitos), na segunda refatoração dela na função `Ola`, a linha `if idioma == "Espanhol" {` causaria uma falha nos testes, porque esse é o único lugar em que a string "Espanhol" é utilizada na seção inteira, quando deveria ser "espanhol".

Se eu tiver me enganado, por favor desconsiderem :)