### PR TITLE
Traduzir "got != want" em arrays-e-slices.md

### DIFF
--- a/primeiros-passos-com-go/arrays-e-slices/arrays-e-slices.md
+++ b/primeiros-passos-com-go/arrays-e-slices/arrays-e-slices.md
@@ -260,7 +260,7 @@ func SomaTudo(numerosParaSomar ...[]int) (somas []int) {
 
 Pode tentar compilar, mas nossos testes não vão funcionar!
 
-`./soma_test.go:26:9: invalid operation: got != want (slice can only be compared to nil)`
+`./soma_test.go:26:9: invalid operation: resultado != esperado (slice can only be compared to nil)`
 
 `operação inválida: recebido != esperado (slice só pode ser comparado a nil`
 


### PR DESCRIPTION
No meio da página "Arrays e Slices", existe o seguinte trecho:

`./soma_test.go:26:9: invalid operation: got != want (slice can only be compared to nil)`

No código do tutorial em que esse erro acontece, as variáveis `got` e `want` foram traduzidas para `resultado` e `esperado`. Esse PR faz isso, então :)